### PR TITLE
Add support for Private CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,24 @@ FlowFuse driver to create projects as docker containers
 
 ## Configuration
 
+## Configuration
+
+In the `flowforge.yml` file
+
+```yaml
+...
+driver:
+  type: docker
+  options:
+    socket: /var/run/docker.sock
+    registry: containers.flowforge.com
+    privateCA: /full/path/to/chain.pem
+```
+
+ - `registry` is the Docker Registry to load Stack Containers from (default: Docker Hub)
+ - `socket` is the path to the docker unix domain socket (default: /var/run/docker.sock)
+ - privateCA: is the fully qualified path to a pem file containing trusted CA cert chain (default: not set)
+
+### Configuration via environment variables
+
  - `DOCKER_SOCKET` - Path to docker unix domain socket

--- a/docker.js
+++ b/docker.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const got = require('got')
 const Docker = require('dockerode')
 
@@ -85,7 +86,7 @@ const createContainer = async (project, domain) => {
         contOptions.Env.push(`FORGE_NR_SECRET=${credentialSecret}`)
     }
 
-    if (this._app.config.driver.options.privateCA) {
+    if (this._app.config.driver.options.privateCA && fs.existsSync(this._app.config.driver.options.privateCA)) {
         contOptions.Binds = [
             `${this._app.config.driver.options.privateCA}:/usr/local/ssl-certs/chain.pem`
         ]

--- a/docker.js
+++ b/docker.js
@@ -85,6 +85,13 @@ const createContainer = async (project, domain) => {
         contOptions.Env.push(`FORGE_NR_SECRET=${credentialSecret}`)
     }
 
+    if (this._app.config.driver.options.privateCA) {
+        contOptions.Binds = [
+            `${this._app.config.driver.options.privateCA}:/usr/local/ssl-certs/chain.pem`
+        ]
+        contOptions.Env.push('NODE_EXTRA_CA_CERTS=/usr/local/ssl-certs/chain.pem')
+    }
+
     const container = await this._docker.createContainer(contOptions)
     return container.start()
         .then(async () => {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Matching functionality from K8s driver

Adding ability to supply a path to a pem file containing CA cert chains for the Node-RED Instance's to trust

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

