### PR TITLE
Pull missing Stack containers on first use

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -97,7 +97,6 @@ const createContainer = async (project, domain) => {
         contOptions.Env.push('NODE_EXTRA_CA_CERTS=/usr/local/ssl-certs/chain.pem')
     }
 
-
     const containerList = await this._docker.listImages()
     let containerFound = false
     for (const cont of containerList) {
@@ -113,15 +112,19 @@ const createContainer = async (project, domain) => {
         try {
             await new Promise((resolve, reject) => {
                 this._docker.pull(stack.container, (err, stream) => {
-                    this._docker.modem.followProgress(stream, onFinished)
-                    function onFinished(err, output) {
-                        if (!err) {
-                            resolve(true)
-                            return
+                    if (!err) {
+                        this._docker.modem.followProgress(stream, onFinished)
+                        function onFinished (err, output) {
+                            if (!err) {
+                                resolve(true)
+                                return
+                            }
+                            reject(err)
                         }
+                    } else {
                         reject(err)
                     }
-                } )
+                })
             })
         } catch (err) {
             this._app.log.debug(`Error pulling image ${stack.container} ${err.message}`)

--- a/docker.js
+++ b/docker.js
@@ -108,7 +108,7 @@ const createContainer = async (project, domain) => {
     }
 
     if (!containerFound) {
-        this._app.log.debug(`Container for stack ${stack.name} not found, pulling ${stack.container}`)
+        this._app.log.info(`Container for stack ${stack.name} not found, pulling ${stack.container}`)
         try {
             await new Promise((resolve, reject) => {
                 this._docker.pull(stack.container, (err, stream) => {
@@ -123,8 +123,7 @@ const createContainer = async (project, domain) => {
                 } )
             })
         } catch (err) {
-            this._app.log.debug(`Error pulling image ${stack.container}`)
-            console.log(err)
+            this._app.log.debug(`Error pulling image ${stack.container} ${err.message}`)
         }
     }
 

--- a/docker.js
+++ b/docker.js
@@ -108,10 +108,12 @@ const createContainer = async (project, domain) => {
     }
 
     if (!containerFound) {
+        this._app.log.debug(`Container for stack ${stack.name} not found, pulling ${stack.container}`)
         try {
             await this._docker.createImage({ fromImage: stack.container})
         } catch (err) {
-            this._app.log.error(`Error pulling image ${stack.container}`)
+            this._app.log.debug(`Error pulling image ${stack.container}`)
+            console.log(err)
         }
     }
 

--- a/docker.js
+++ b/docker.js
@@ -97,6 +97,24 @@ const createContainer = async (project, domain) => {
         contOptions.Env.push('NODE_EXTRA_CA_CERTS=/usr/local/ssl-certs/chain.pem')
     }
 
+
+    const containerList = await this._docker.listImages()
+    let containerFound = false
+    for (const cont of containerList) {
+        if (cont.RepoTags.includes(stack.container)) {
+            containerFound = true
+            break
+        }
+    }
+
+    if (!containerFound) {
+        try {
+            await this._docker.createImage({ fromImage: stack.container})
+        } catch (err) {
+            this._app.log.error(`Error pulling image ${stack.container}`)
+        }
+    }
+
     const container = await this._docker.createContainer(contOptions)
     return container.start()
         .then(async () => {

--- a/docker.js
+++ b/docker.js
@@ -109,6 +109,7 @@ const createContainer = async (project, domain) => {
 
     if (!containerFound) {
         this._app.log.info(`Container for stack ${stack.name} not found, pulling ${stack.container}`)
+        // https://github.com/apocas/dockerode/issues/703
         try {
             await new Promise((resolve, reject) => {
                 this._docker.pull(stack.container, (err, stream) => {

--- a/docker.js
+++ b/docker.js
@@ -110,7 +110,18 @@ const createContainer = async (project, domain) => {
     if (!containerFound) {
         this._app.log.debug(`Container for stack ${stack.name} not found, pulling ${stack.container}`)
         try {
-            await this._docker.createImage({ fromImage: stack.container})
+            await new Promise((resolve, reject) => {
+                this._docker.pull(stack.container, (err, stream) => {
+                    this._docker.modem.followProgress(stream, onFinished)
+                    function onFinished(err, output) {
+                        if (!err) {
+                            resolve(true)
+                            return
+                        }
+                        reject(err)
+                    }
+                } )
+            })
         } catch (err) {
             this._app.log.debug(`Error pulling image ${stack.container}`)
             console.log(err)


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
If a new stack is added without the container image being present on the machine the driver will now try and pull the container.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
Request on NR Slack

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

