### PR TITLE
Fix loading private CA certs in Instances

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -90,7 +90,7 @@ const createContainer = async (project, domain) => {
         contOptions.Env.push('FORGE_LOG_PASSTHROUGH=true')
     }
 
-    if (this._app.config.driver.options?.privateCA && fs.existsSync(this._app.config.driver.options?.privateCA)) {
+    if (this._app.config.driver.options?.privateCA) {
         contOptions.Binds = [
             `${this._app.config.driver.options.privateCA}:/usr/local/ssl-certs/chain.pem`
         ]

--- a/docker.js
+++ b/docker.js
@@ -1,4 +1,3 @@
-const fs = require('fs')
 const got = require('got')
 const Docker = require('dockerode')
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
It was checking the path to the file existed inside the forge container, but the value is the file on the host to mount

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

