### PR TITLE
Bump for 2.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.2.1: Release
+
+ - Fix loading private CA certs in Instances (#87) @hardillb
+
 #### 2.2.0: Release
 
  - Pull missing Stack containers on first use (#85) @hardillb

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@flowfuse/driver-docker",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@flowfuse/driver-docker",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "dockerode": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowfuse/driver-docker",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "Docker driver for FlowFuse",
     "main": "docker.js",
     "scripts": {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

2.2.1 point release

(note that we have already done a FF and a docker-compose 2.2.1 so this will ship in 2.2.2)