### PR TITLE
Only pull stack container if missing

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -98,8 +98,13 @@ const createContainer = async (project, domain) => {
 
     const containerList = await this._docker.listImages()
     let containerFound = false
+    let stackName = stack.container
+    // add ":latest" to stack containers with no tag
+    if (stackName.indexOf(':') === -1) {
+        stackName = stackName + ':latest'
+    }
     for (const cont of containerList) {
-        if (cont.RepoTags.includes(stack.container)) {
+        if (cont.RepoTags.includes(stackName)) {
             containerFound = true
             break
         }
@@ -474,7 +479,7 @@ module.exports = {
         const properties = {
             cpu: 10,
             memory: 256,
-            container: 'flowfuse/node-red',
+            container: 'flowfuse/node-red:latest',
             ...this._app.config.driver.options?.default_stack
         }
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
The test for if the stack image was available as always failing when the image name has no tag, because docker automatically adds `:latest` when pulling that tag.

Also make the default container image specific

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

