### PR TITLE
Add support for user set health check interval

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -392,6 +392,7 @@ module.exports = {
         settings.port = 1880
         settings.rootDir = '/'
         settings.userDir = 'data'
+        settings.healthCheckInterval = await project.getSetting('healthCheckInterval')
 
         return settings
     },


### PR DESCRIPTION
closes #91

## Description

Maps `healthCheckInterval` into settings so that a user set value can be passed to the `Launcher.start` call
NOTES:
* Can be approved any time, but should only be merged once all related PRs are approved:
   * https://github.com/FlowFuse/flowfuse/pull/3716
   * https://github.com/FlowFuse/driver-localfs/pull/124
   * https://github.com/FlowFuse/driver-k8s/pull/150
   * https://github.com/FlowFuse/nr-launcher/pull/228


## Related Issue(s)

#91

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

