### PR TITLE
Fix network selection if more than one network labeled 'flowforge'

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -182,8 +182,8 @@ module.exports = {
         const networks = await this._docker.listNetworks({ filters: { label: ['com.docker.compose.network=flowforge'] } })
         const filteredNetworks = networks.filter(net => {
             const containers = Object.keys(net.Containers)
-            for (let i=0; i < containers.length; i++) {
-                if (containers[i].startsWith(env.process.HOSTNAME)) {
+            for (let i = 0; i < containers.length; i++) {
+                if (containers[i].startsWith(process.env.HOSTNAME)) {
                     return true
                 }
             }

--- a/docker.js
+++ b/docker.js
@@ -183,7 +183,8 @@ module.exports = {
         console.log(networks)
         console.log(process.env.HOSTNAME)
         const filteredNetworks = networks.filter(net => {
-            const containers = Object.keys(net.Containers)
+            const details = await this._docker.getNetwork(net.Id).inspect()
+            const containers = Object.keys(details.Containers)
             for (let i = 0; i < containers.length; i++) {
                 console.log(containers[i])
                 if (containers[i].startsWith(process.env.HOSTNAME)) {

--- a/docker.js
+++ b/docker.js
@@ -180,9 +180,7 @@ module.exports = {
         }
 
         const networks = await this._docker.listNetworks({ filters: { label: ['com.docker.compose.network=flowforge'] } })
-        console.log(networks)
-        console.log(process.env.HOSTNAME)
-        // if (networks.length > 1) {
+        if (networks.length > 1) {
             const filteredNetworks = networks.filter(async net => {
                 const details = await this._docker.getNetwork(net.Id).inspect()
                 const containers = Object.keys(details.Containers)
@@ -194,8 +192,6 @@ module.exports = {
                 }
                 return false
             })
-            console.log("filtered")
-            console.log(JSON.stringify(filteredNetworks, null, 2))
             if (filteredNetworks[0]) {
                 this._app.log.info(`[docker] using network ${filteredNetworks[0].Name}`)
                 this._network = filteredNetworks[0].Name
@@ -203,10 +199,10 @@ module.exports = {
                 this._app.log.info('[docker] unable to find network')
                 process.exit(-9)
             }
-        // } else {
-        //     this._app.log.info(`[docker] using network ${networks[0].Name}`)
-        //     this._network = networks[0].Name
-        // }
+        } else {
+            this._app.log.info(`[docker] using network ${networks[0].Name}`)
+            this._network = networks[0].Name
+        }
         
 
         // Get a list of all projects - with the absolute minimum of fields returned

--- a/docker.js
+++ b/docker.js
@@ -186,13 +186,13 @@ module.exports = {
                 const details = await this._docker.getNetwork(networks[j].Id).inspect()
                 const containers = Object.keys(details.Containers)
                 for (let i = 0; i < containers.length; i++) {
-                    console.log(containers[i])
+                    // console.log(containers[i])
                     if (containers[i].startsWith(process.env.HOSTNAME)) {
                         filteredNetworks.push(networks[j])
                     }
                 }
             }
-            console.log(JSON.stringify(filteredNetworks))
+            // console.log(JSON.stringify(filteredNetworks, null, 2))
             if (filteredNetworks[0]) {
                 this._app.log.info(`[docker] using network ${filteredNetworks[0].Name}`)
                 this._network = filteredNetworks[0].Name

--- a/docker.js
+++ b/docker.js
@@ -181,17 +181,18 @@ module.exports = {
 
         const networks = await this._docker.listNetworks({ filters: { label: ['com.docker.compose.network=flowforge'] } })
         if (networks.length > 1) {
-            const filteredNetworks = networks.filter(async net => {
-                const details = await this._docker.getNetwork(net.Id).inspect()
+            const filteredNetworks = []
+            for (let j = 0; j < networks.length; j++) {
+                const details = await this._docker.getNetwork(networks[j].Id).inspect()
                 const containers = Object.keys(details.Containers)
                 for (let i = 0; i < containers.length; i++) {
                     console.log(containers[i])
                     if (containers[i].startsWith(process.env.HOSTNAME)) {
-                        return true
+                        filteredNetworks.push(networks[j])
                     }
                 }
-                return false
-            })
+            }
+            console.log(JSON.stringify(filteredNetworks))
             if (filteredNetworks[0]) {
                 this._app.log.info(`[docker] using network ${filteredNetworks[0].Name}`)
                 this._network = filteredNetworks[0].Name

--- a/docker.js
+++ b/docker.js
@@ -203,7 +203,6 @@ module.exports = {
             this._app.log.info(`[docker] using network ${networks[0].Name}`)
             this._network = networks[0].Name
         }
-        
 
         // Get a list of all projects - with the absolute minimum of fields returned
         const projects = await app.db.models.Project.findAll({

--- a/docker.js
+++ b/docker.js
@@ -200,9 +200,12 @@ module.exports = {
                 this._app.log.info('[docker] unable to find network')
                 process.exit(-9)
             }
-        } else {
+        } else if (networks.length === 1) {
             this._app.log.info(`[docker] using network ${networks[0].Name}`)
             this._network = networks[0].Name
+        } else {
+            this._app.log.info('[docker] unable to find network')
+            process.exit(-9)
         }
 
         // Get a list of all projects - with the absolute minimum of fields returned

--- a/docker.js
+++ b/docker.js
@@ -180,16 +180,20 @@ module.exports = {
         }
 
         const networks = await this._docker.listNetworks({ filters: { label: ['com.docker.compose.network=flowforge'] } })
+        console.log(networks)
+        console.log(process.env.HOSTNAME)
         const filteredNetworks = networks.filter(net => {
             const containers = Object.keys(net.Containers)
             for (let i = 0; i < containers.length; i++) {
+                console.log(containers[i])
                 if (containers[i].startsWith(process.env.HOSTNAME)) {
                     return true
                 }
             }
             return false
         })
-
+        console.log("filetered")
+        console.log(JSON.stringify(filteredNetworks, null, 2))
         this._network = filteredNetworks[0].Name
 
         // Get a list of all projects - with the absolute minimum of fields returned


### PR DESCRIPTION
fixes #65 
## Description

<!-- Describe your changes in detail -->
Looks up the network the forge app is using to ensure the correct network is assigned to NR Instances.

Tested with local builds

## Related Issue(s)
#65

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

