### PR TITLE
both storage options required (enabled & path

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -102,7 +102,7 @@ const createContainer = async (project, domain) => {
         contOptions.Env.push('NODE_EXTRA_CA_CERTS=/usr/local/ssl-certs/chain.pem')
     }
 
-    if (this._app.config.driver.options?.storage?.enabled || this._app.config.driver.options?.storage?.path) {
+    if (this._app.config.driver.options?.storage?.enabled && this._app.config.driver.options?.storage?.path) {
         try {
             const localPath = path.join('/opt/persistent-storage', project.id)
             console.log(`Creating dir in container ${localPath}`)


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
While checking on configuration bug I noticed this should be both not or for enabled and the path

The docs do say both is required, but this is to make it explicit

## Related Issue(s)

<!-- What issue does this PR relate to? -->
NA

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

