### PR TITLE
Log the correct Stack Name when pulling image

### DIFF
--- a/docker.js
+++ b/docker.js
@@ -139,7 +139,7 @@ const createContainer = async (project, domain) => {
     }
 
     if (!containerFound) {
-        this._app.log.info(`Container for stack ${stack.name} not found, pulling ${stack.container}`)
+        this._app.log.info(`Container for stack ${project.ProjectStack.name} not found, pulling ${stack.container}`)
         // https://github.com/apocas/dockerode/issues/703
         try {
             await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
`stack` was not the full stack object, just it's properties

## Related Issue(s)

<!-- What issue does this PR relate to? -->

Found while testing broker setup