### PR TITLE
feat: Use docker volume as persistent storage backend for project instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ driver:
  - `socket` is the path to the docker unix domain socket (default: /var/run/docker.sock)
  - `privateCA`: is the fully qualified path to a pem file containing trusted CA cert chain (default: not set)
  - `logPassthrough` Have Node-RED logs printed in JSON format to container stdout (default: false)
- - `storage.enabled` enables mounting a directory into each Node-RED instance as persistence storage (default: false)
- - `storage.path` is the fully qualified path to the root directory for the storage on the host (default: not set)
+ - `storage.enabled` enables volume-based persistent storage for Node-RED instance (default: false)
 
 ### Configuration via environment variables
 

--- a/docker.js
+++ b/docker.js
@@ -1,8 +1,6 @@
 const got = require('got')
 const FormData = require('form-data')
 const Docker = require('dockerode')
-const path = require('path')
-const { chownSync, mkdirSync, rmSync } = require('fs')
 
 const createContainer = async (project, domain) => {
     const stack = project.ProjectStack.properties
@@ -111,7 +109,7 @@ const createContainer = async (project, domain) => {
             await this._docker.createVolume({
                 Name: volumeName,
                 Labels: {
-                    'flowfuse': 'project-storage',
+                    flowfuse: 'project-storage',
                     'project-id': project.id
                 }
             })


### PR DESCRIPTION
## Description

This pull request replaces current approach for Project Instances persistant storage. Instead of storing data on the docker host, [Docker Volumes](https://docs.docker.com/engine/storage/volumes/) are utilised.

## Related Issue(s)

Closes https://github.com/FlowFuse/flowfuse/issues/5199

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

