### PR TITLE
docs: Remove unused configuration keyfrom README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ driver:
     logPassthrough: true
     storage:
       enabled: true
-      path: /opt/flowfuse/storage
 ```
 
  - `registry` is the Docker Registry to load Stack Containers from (default: Docker Hub)


### PR DESCRIPTION
## Description

Remove unused `storage.path` configuration key.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

